### PR TITLE
Fixed the overflow in the NumberInput Control

### DIFF
--- a/src/Common/Controls/NumberInput.cs
+++ b/src/Common/Controls/NumberInput.cs
@@ -9,6 +9,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Audio;
 using Microsoft.Xna.Framework.Graphics;
 
+using MonoGame.Extended;
 using MonoGame.Extended.BitmapFonts;
 
 using Mouse = Microsoft.Xna.Framework.Input.Mouse;
@@ -244,7 +245,7 @@ public class NumberInput : TextInputBase
                 (int)highlightStart - 1,
                 _textRectangle.Y,
                 (int)highlightWidth,
-                _font.LineHeight - 1);
+                _font.LineHeight - 1).Clip(_textBoxRectangle);
         }
     }
 
@@ -366,6 +367,21 @@ public class NumberInput : TextInputBase
         EnterPressed?.Invoke(this, EventArgs.Empty);
     }
 
+    /// <remarks>
+    /// Direct copy of <see cref="TextInputBase.PaintText(SpriteBatch, Rectangle, HorizontalAlignment)"/>
+    /// that also exposes the clippingRectangle parameter of
+    /// <see cref="BitmapFontExtensions.DrawString(SpriteBatch, BitmapFont, string, Vector2, Color, Rectangle?)"/>.
+    /// </remarks>
+    protected virtual void PaintText(SpriteBatch spriteBatch, Rectangle textRegion, HorizontalAlignment horizontalAlignment = HorizontalAlignment.Left, Rectangle? clippingRectangle = null)
+    {
+        if (!_focused && _text.Length == 0)
+        {
+            spriteBatch.DrawStringOnCtrl(this, _placeholderText, _font, textRegion, Color.LightGray, false, false, 0, horizontalAlignment, VerticalAlignment.Top, clippingRectangle);
+        }
+
+        spriteBatch.DrawStringOnCtrl(this, _text, _font, textRegion, _foreColor, false, false, 0, horizontalAlignment, VerticalAlignment.Top, clippingRectangle);
+    }
+
     protected override void Paint(SpriteBatch spriteBatch, Rectangle bounds)
     {
         #region Text
@@ -390,8 +406,8 @@ public class NumberInput : TextInputBase
                 }
             }
         }
-
-        PaintText(spriteBatch, _textRectangle, HorizontalAlignment.Right);
+        
+        PaintText(spriteBatch, _textRectangle, HorizontalAlignment.Right, _textBoxRectangle);
 
         #endregion Text
 

--- a/src/Common/SpriteBatchExtensions.cs
+++ b/src/Common/SpriteBatchExtensions.cs
@@ -1,0 +1,112 @@
+﻿using Blish_HUD;
+using Blish_HUD.Controls;
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+using MonoGame.Extended.BitmapFonts;
+
+namespace SL.Common
+{
+    public static class SpriteBatchExtensions
+    {
+        /// <remarks>
+        /// This is basically a copy of
+        /// <see cref="Blish_HUD.SpriteBatchExtensions.DrawStringOnCtrl(SpriteBatch, Control, string, BitmapFont, Rectangle, Color, bool, bool, int, HorizontalAlignment, VerticalAlignment)"/>
+        /// that also exposes the clippingRectangle parameter of
+        /// <see cref="BitmapFontExtensions.DrawString(SpriteBatch, BitmapFont, string, Vector2, Color, Rectangle?)"/>.
+        /// 
+        /// This should probably be in Blish HUD Core and can be removed here, if it is added at some point.
+        /// </remarks>
+        public static void DrawStringOnCtrl(this SpriteBatch spriteBatch,
+                                            Control ctrl,
+                                            string text,
+                                            BitmapFont font,
+                                            Rectangle destinationRectangle,
+                                            Color color,
+                                            bool wrap,
+                                            bool stroke,
+                                            int strokeDistance = 1,
+                                            HorizontalAlignment horizontalAlignment = HorizontalAlignment.Left,
+                                            VerticalAlignment verticalAlignment = VerticalAlignment.Middle,
+                                            Rectangle? clippingRectangle = null)
+        {
+
+            if (string.IsNullOrEmpty(text)) return;
+
+            text = wrap ? DrawUtil.WrapText(font, text, destinationRectangle.Width) : text;
+
+            // TODO: This does not account for vertical alignment
+            if (horizontalAlignment != HorizontalAlignment.Left && (wrap || text.Contains("\n")))
+            {
+                using (StringReader reader = new StringReader(text))
+                {
+                    string line;
+
+                    int lineHeightDiff = 0;
+
+                    while (destinationRectangle.Height - lineHeightDiff > 0 && (line = reader.ReadLine()) != null)
+                    {
+                        DrawStringOnCtrl(spriteBatch, ctrl, line, font, destinationRectangle.Add(0, lineHeightDiff, 0, -0), color, wrap, stroke, strokeDistance, horizontalAlignment, verticalAlignment, clippingRectangle);
+
+                        lineHeightDiff += font.LineHeight;
+                    }
+                }
+
+                return;
+            }
+
+            Vector2 textSize = font.MeasureString(text);
+
+            if (clippingRectangle.HasValue)
+            {
+                clippingRectangle = clippingRectangle.Value.ToBounds(ctrl.AbsoluteBounds);
+            }
+
+            destinationRectangle = destinationRectangle.ToBounds(ctrl.AbsoluteBounds);
+
+            int xPos = destinationRectangle.X;
+            int yPos = destinationRectangle.Y;
+
+            switch (horizontalAlignment)
+            {
+                case HorizontalAlignment.Center:
+                    xPos += destinationRectangle.Width / 2 - (int)textSize.X / 2;
+                    break;
+                case HorizontalAlignment.Right:
+                    xPos += destinationRectangle.Width - (int)textSize.X;
+                    break;
+            }
+
+            switch (verticalAlignment)
+            {
+                case VerticalAlignment.Middle:
+                    yPos += destinationRectangle.Height / 2 - (int)textSize.Y / 2;
+                    break;
+                case VerticalAlignment.Bottom:
+                    yPos += destinationRectangle.Height - (int)textSize.Y;
+                    break;
+            }
+
+            var textPos = new Vector2(xPos, yPos);
+
+            float absoluteOpacity = ctrl.AbsoluteOpacity();
+
+            if (stroke)
+            {
+                var strokePreMultiplied = Color.Black * absoluteOpacity;
+
+                spriteBatch.DrawString(font, text, textPos.OffsetBy(0, -strokeDistance), strokePreMultiplied, clippingRectangle);
+                spriteBatch.DrawString(font, text, textPos.OffsetBy(strokeDistance, -strokeDistance), strokePreMultiplied, clippingRectangle);
+                spriteBatch.DrawString(font, text, textPos.OffsetBy(strokeDistance, 0), strokePreMultiplied, clippingRectangle);
+                spriteBatch.DrawString(font, text, textPos.OffsetBy(strokeDistance, strokeDistance), strokePreMultiplied, clippingRectangle);
+                spriteBatch.DrawString(font, text, textPos.OffsetBy(0, strokeDistance), strokePreMultiplied, clippingRectangle);
+                spriteBatch.DrawString(font, text, textPos.OffsetBy(-strokeDistance, strokeDistance), strokePreMultiplied, clippingRectangle);
+                spriteBatch.DrawString(font, text, textPos.OffsetBy(-strokeDistance, 0), strokePreMultiplied, clippingRectangle);
+                spriteBatch.DrawString(font, text, textPos.OffsetBy(-strokeDistance, -strokeDistance), strokePreMultiplied, clippingRectangle);
+            }
+
+            spriteBatch.DrawString(font, text, textPos, color * absoluteOpacity, clippingRectangle);
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes the overflow of the NumberInput Control.

The underlying `SpriteBatch.DrawString(..)` method accepts a `clippingRectangle` that is not exposed by Blish HUD Core. This PR adds an extension method that exposes the parameter and makes use of this added method.

At some point the extension method should probably be moved to Core, but for now this is the best solution.

There's also a small fix in there, that stops the highlighted selection to overflow the text part of the `Control`.

## detailed changes

- added `SpriteBatchExtensions`
- added a `spriteBatch.DrawStringOnCtrl()` overload that exposes the `clippingRectangle` parameter of the underlying `spriteBatch.DrawString()` method
- added a `PaintText()` method to `NumberInput` that makes use of the added method
- modified `NumberInput.Paint()` to make use of the new method
- fixed the `HighlightRectangle` overflowing the text area